### PR TITLE
Add retries parameter to exponential backoff strategy

### DIFF
--- a/lib/cassanity/retry_strategies/exponential_backoff.rb
+++ b/lib/cassanity/retry_strategies/exponential_backoff.rb
@@ -6,7 +6,23 @@ module Cassanity
       # Taken from https://github.com/twitter/kestrel-client's blocking client.
       SLEEP_TIMES = [[0] * 1, [0.01] * 2, [0.1] * 2, [0.5] * 2, [1.0] * 1].flatten
 
+      # Private: the maxmimum number of times to retry or -1 to try forever.
+      attr_reader :retries
+
+      # Public: Initialize the retry strategy.
+      #
+      # args   - The Hash of options.
+      #          :retries - the maximum number of times to retry or -1 to try
+      #                     forever.
+      def initialize(args = {})
+        # The default behavior is to retry forever.
+        @retries = args[:retries] || -1
+      end
+
       def fail(attempts, error)
+        if @retries >= 0 && attempts > @retries
+          raise error
+        end
         sleep_for_count(attempts)
       end
 

--- a/spec/unit/cassanity/retry_strategies/exponential_backoff_spec.rb
+++ b/spec/unit/cassanity/retry_strategies/exponential_backoff_spec.rb
@@ -10,5 +10,28 @@ describe Cassanity::RetryStrategies::ExponentialBackoff do
 
       lambda { subject.execute { raise cassandra_error('An error!') } }.should raise_error(RuntimeError, 'Stop!')
     end
+
+    it "retries unsuccessful calls up to :retries times, stopping on success" do
+      executor = double('Executor')
+
+      i = 0
+      retries = 5
+
+      # Raise errors for a bit, then succeed.
+      executor.stub(:execute) {
+        i += 1
+        if i <= retries
+          raise cassandra_error('An error!')
+        else
+          :return
+        end
+      }
+
+      executor.should_receive(:execute).exactly(retries + 1).times.with('arg')
+
+      instance = described_class.new(:retries => retries)
+      instance.should_receive(:sleep).exactly(retries).times
+      instance.execute { executor.execute('arg') }.should eq(:return)
+    end
   end
 end


### PR DESCRIPTION
Adds retries parameter to exponential backoff class. Default is to retry forever ala kestrel blocking client.
