### PR TITLE
Store version as text not as integer

### DIFF
--- a/lib/cassanity/migration_proxy.rb
+++ b/lib/cassanity/migration_proxy.rb
@@ -23,7 +23,7 @@ module Cassanity
       raise ArgumentError, "name cannot be nil" if name.nil?
 
       @path = Pathname(path)
-      @version = version.to_i
+      @version = version
       @name = name
     end
 

--- a/lib/cassanity/migrator.rb
+++ b/lib/cassanity/migrator.rb
@@ -38,9 +38,9 @@ module Cassanity
 
       migrations = case direction
       when :up
-        pending_migrations.select { |migration| migration.version <= version }
+        pending_migrations.select { |migration| migration.version.to_i <= version }
       when :down
-        performed_migrations.select { |migration| migration.version > version }
+        performed_migrations.select { |migration| migration.version.to_i > version }
       else
         []
       end


### PR DESCRIPTION
To support versions of the form '001' that otherwise would not be found
on disk under the 1_ prefix.

The type of the database column `version` was already text, so this was
probably the original intention.
