### PR TITLE
Don't merge in defaults for NetworkTopologyStrategy keyspace creation

### DIFF
--- a/lib/cassanity/argument_generators/keyspace_create.rb
+++ b/lib/cassanity/argument_generators/keyspace_create.rb
@@ -14,7 +14,11 @@ module Cassanity
         name = args.fetch(:keyspace_name)
         cql = "CREATE KEYSPACE #{name}"
 
-        replication = default_replication_options.merge(args[:replication] || {})
+        replication = args.fetch(:replication, {})
+
+        if replication.empty? || replication[:class] !~ /NetworkTopologyStrategy/
+          replication = default_replication_options.merge(replication)
+        end
 
         with_cql, *with_variables = @with_clause.call(with: { replication: replication })
         cql << with_cql

--- a/spec/unit/cassanity/argument_generators/keyspace_create_spec.rb
+++ b/spec/unit/cassanity/argument_generators/keyspace_create_spec.rb
@@ -24,6 +24,17 @@ describe Cassanity::ArgumentGenerators::KeyspaceCreate do
       end
     end
 
+    context "overriding replication class with NetworkTopologyStrategy" do
+      it "doesn't merge in replication_factor" do
+        cql = "CREATE KEYSPACE #{keyspace_name} WITH replication = ?"
+        expected = [cql, {class: 'NetworkTopologyStrategy', datacenter1: 1}]
+        subject.call({
+          keyspace_name: keyspace_name,
+          replication: {class: 'NetworkTopologyStrategy', datacenter1: 1},
+        }).should eq(expected)
+      end
+    end
+
     context "overriding a default strategy_option" do
       it "returns array of arguments" do
         cql = "CREATE KEYSPACE #{keyspace_name} WITH replication = ?"


### PR DESCRIPTION
It conflicts with other replication values for this strategy, such as 'datacenter: 1' or 'dc1: 3' etc.

Trying to use a replication strategy of `{:class=>"NetworkTopologyStrategy", :datacenter1=>1}` I got the error `Cql::QueryError: Error constructing replication strategy class` when creating a keyspace. With a bit of instrumentation (debug output shown below), we see that the keyspace_create argument generator merges in the default arguments, including `replication_factor`, which results in a conflict with the different syntax of NetworkTopologyStrategy replication.

This is a bit of a hack, but avoids merging the replication factor for NetworkTopologyStrategy. The consequence is that if you use NetworkTopologyStrategy you must also specify your replication factor(s), but if you're using NetworkTopologyStrategy you probably need to do that anyway.

```
create_arguments
{:replication=>{:class=>"NetworkTopologyStrategy", :datacenter1=>1}, :keyspace_name=>:mydrive_cql_development}
CREATE KEYSPACE mydrive_cql_development WITH replication = {'class':'NetworkTopologyStrategy','replication_factor':1,'datacenter1':1}
rake aborted!
Original Exception: Cql::QueryError: Error constructing replication strategy class
/Users/gavin/src/cassanity/lib/cassanity/executors/cql_rb.rb:191:in `rescue in block in call'
/Users/gavin/src/cassanity/lib/cassanity/executors/cql_rb.rb:175:in `block in call'
/Users/gavin/src/cassanity/lib/cassanity/instrumenters/noop.rb:5:in `instrument'
/Users/gavin/src/cassanity/lib/cassanity/executors/cql_rb.rb:140:in `call'
/Users/gavin/src/cassanity/lib/cassanity/keyspace.rb:75:in `create'
```
