### PR TITLE
Support composite partition key as part of composite primary key

### DIFF
--- a/lib/cassanity/argument_generators/column_family_create.rb
+++ b/lib/cassanity/argument_generators/column_family_create.rb
@@ -27,7 +27,7 @@ module Cassanity
           definitions << "#{name} #{type}"
         end
 
-        definitions << "PRIMARY KEY (#{primary_keys.join(', ')})"
+        definitions << "PRIMARY KEY (#{compose_primary_key(primary_keys).join(', ')})"
 
         cql_definition = definitions.join(', ')
 
@@ -38,6 +38,16 @@ module Cassanity
         variables.concat(with_variables)
 
         [cql, *variables]
+      end
+
+      def compose_primary_key(primary_keys)
+        primary_keys.map do |key|
+          if key.is_a? Array
+            "(#{key.join(', ')})"
+          else
+            key
+          end
+        end
       end
     end
   end

--- a/lib/cassanity/schema.rb
+++ b/lib/cassanity/schema.rb
@@ -57,8 +57,8 @@ module Cassanity
 
     # Private
     def primary_keys_are_defined_as_columns?
-      shared_columns = column_names & @primary_keys
-      shared_columns == @primary_keys
+      shared_columns = column_names & @primary_keys.flatten
+      shared_columns == @primary_keys.flatten
     end
 
     # Public

--- a/spec/unit/cassanity/argument_generators/column_family_create_spec.rb
+++ b/spec/unit/cassanity/argument_generators/column_family_create_spec.rb
@@ -73,6 +73,26 @@ describe Cassanity::ArgumentGenerators::ColumnFamilyCreate do
       end
     end
 
+    context "when using composite partition key" do
+      it "returns array of arguments" do
+        schema = Cassanity::Schema.new({
+          primary_key: [[:segment, :line], :track_id],
+          columns: {
+            segment: :text,
+            line: :int,
+            track_id: :timeuuid,
+            page: :text,
+          },
+        })
+        cql = "CREATE COLUMNFAMILY #{column_family_name} (segment text, line int, track_id timeuuid, page text, PRIMARY KEY ((segment, line), track_id))"
+        expected = [cql]
+        subject.call({
+          column_family_name: column_family_name,
+          schema: schema,
+        }).should eq(expected)
+      end
+    end
+
     context "when using WITH options" do
       let(:with_clause) {
         lambda { |args| [" WITH comment = ?", 'Testing']}

--- a/spec/unit/cassanity/schema_spec.rb
+++ b/spec/unit/cassanity/schema_spec.rb
@@ -23,8 +23,21 @@ describe Cassanity::Schema do
     }
   }
 
+  let(:composite_partition_required_arguments) {
+    {
+      primary_key: [[:bucket, :version], :id],
+      columns: {
+        bucket: :text,
+        version: :text,
+        id: :text,
+        name: :text,
+      }
+    }
+  }
+
   let(:schema) { described_class.new(required_arguments) }
   let(:composite_schema) { described_class.new(composite_required_arguments) }
+  let(:composite_partition_schema) { described_class.new(composite_partition_required_arguments) }
 
   subject { schema }
 
@@ -78,6 +91,14 @@ describe Cassanity::Schema do
         subject.primary_keys.should eq([:bucket, :id])
       end
     end
+
+    context "with composite partition key" do
+      subject { composite_partition_schema }
+
+      it "returns array of primary keys with array of partition" do
+        subject.primary_keys.should eq([[:bucket, :version], :id])
+      end
+    end
   end
 
   describe "#primary_key" do
@@ -96,6 +117,14 @@ describe Cassanity::Schema do
         subject.primary_key.should eq([:bucket, :id])
       end
     end
+
+    context "with composite partition key" do
+      subject { composite_partition_schema }
+
+      it "returns array of primary keys with array of partition" do
+        subject.primary_keys.should eq([[:bucket, :version], :id])
+      end
+    end
   end
 
   describe "#composite_primary_key?" do
@@ -109,6 +138,14 @@ describe Cassanity::Schema do
 
     context "with composite primary key" do
       subject { composite_schema }
+
+      it "returns true" do
+        subject.composite_primary_key?.should be_true
+      end
+    end
+
+    context "with composite partition key" do
+      subject { composite_partition_schema }
 
       it "returns true" do
         subject.composite_primary_key?.should be_true


### PR DESCRIPTION
Enhance the ColumnFamilyCreate generator to support a composite partition key by making the partition key an array of columns, e.g.

``` ruby
create_table :foo, {
  primary_key: [[:id, :version], :field],
  columns: {
    id: :text,
    version: :text,
    field: :text
  }
}
```

Will generate the CQL `create table foo (id text, version text, field text) PRIMARY KEY ((id, version), field);`
