### PR TITLE
Lightweight Transactions

### DIFF
--- a/cassanity.gemspec
+++ b/cassanity.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'cql-rb', '~>1.1', '>=1.1.1'
+  gem.add_dependency 'cql-rb', '~>2.0.0.pre1'
 
   gem.add_development_dependency 'simple_uuid', '~>0.4'
 end

--- a/examples/column_families.rb
+++ b/examples/column_families.rb
@@ -1,7 +1,7 @@
 require_relative '_shared'
 require 'cassanity'
 
-client = Cassanity::Client.new('127.0.0.1:9160', {
+client = Cassanity::Client.new(['127.0.0.1'], 9042, {
   instrumenter: ActiveSupport::Notifications,
 })
 

--- a/examples/column_families.rb
+++ b/examples/column_families.rb
@@ -25,6 +25,9 @@ apps.create
 # insert a row
 apps.insert(data: {id: '1', name: 'GitHub'})
 
+# insert a row only if the row key not exists
+apps.insert(data: {id: '1', name: 'NewGitHub'}, upsert: false)
+
 # insert another row
 apps.insert(data: {id: '2', name: 'Gist'})
 
@@ -33,6 +36,9 @@ pp apps.select
 
 # update a row based on id
 apps.update(set: {name: 'GitHub.com'}, where: {id: '1'})
+
+# update a row if given conditions are met
+apps.update(set: {name: 'GitHub_Modified'}, where: {id: '1'}, if: {name: 'GitHub'})
 
 # print out the rows again, note that GitHub is updated
 pp apps.select

--- a/lib/cassanity/argument_generators/column_family_insert.rb
+++ b/lib/cassanity/argument_generators/column_family_insert.rb
@@ -7,6 +7,7 @@ module Cassanity
         name    = args.fetch(:column_family_name)
         data    = args.fetch(:data)
         using   = args[:using] || {}
+        upsert  = args.fetch(:upsert, true)
         keys    = data.keys
         binders = ['?'] * keys.size
 
@@ -15,6 +16,7 @@ module Cassanity
         end
 
         cql = "INSERT INTO #{name} (#{keys.join(', ')}) VALUES (#{binders.join(', ')})"
+        cql << " IF NOT EXISTS" unless !!upsert
 
         unless using.empty?
           statements = []

--- a/lib/cassanity/argument_generators/column_family_update.rb
+++ b/lib/cassanity/argument_generators/column_family_update.rb
@@ -1,3 +1,4 @@
+require 'cassanity/argument_generators/if_clause'
 require 'cassanity/argument_generators/where_clause'
 require 'cassanity/argument_generators/set_clause'
 require 'cassanity/argument_generators/using_clause'
@@ -11,6 +12,7 @@ module Cassanity
         @using_clause = args.fetch(:using_clause) { UsingClause.new }
         @set_clause   = args.fetch(:set_clause)   { SetClause.new }
         @where_clause = args.fetch(:where_clause) { WhereClause.new }
+        @if_clause    = args.fetch(:if_clause)    { IfClause.new }
       end
 
       # Internal
@@ -18,6 +20,7 @@ module Cassanity
         name  = args.fetch(:column_family_name)
         set   = args.fetch(:set)
         where = args.fetch(:where)
+        ifc   = args[:if] || {}
         using = args[:using] || {}
 
         variables = []
@@ -39,6 +42,10 @@ module Cassanity
         where_cql, *where_variables = @where_clause.call(where: where)
         cql << where_cql
         variables.concat(where_variables)
+
+        if_cql, *if_variables = @if_clause.call(if: ifc)
+        cql << if_cql
+        variables.concat(if_variables)
 
         [cql, *variables]
       end

--- a/lib/cassanity/argument_generators/if_clause.rb
+++ b/lib/cassanity/argument_generators/if_clause.rb
@@ -1,0 +1,32 @@
+require 'cassanity/operators/eq'
+
+module Cassanity
+  module ArgumentGenerators
+    class IfClause
+
+      # Internal
+      def call(args = {})
+        ifc = args[:if]
+        cql = ''
+        return [cql] if ifc.nil? || ifc.empty?
+
+        variables, conditions = [], []
+
+        ifc.each do |key, value|
+          case value
+          when Cassanity::Operators::Eq
+            conditions << "#{key} #{value.symbol} ?"
+            variables << value.value
+          else
+            conditions << "\"#{key}\" = ?"
+            variables << value
+          end
+        end
+
+        cql << " IF #{conditions.join(' AND ')}"
+
+        [cql, *variables]
+      end
+    end
+  end
+end

--- a/spec/unit/cassanity/argument_generators/column_family_insert_spec.rb
+++ b/spec/unit/cassanity/argument_generators/column_family_insert_spec.rb
@@ -66,5 +66,20 @@ describe Cassanity::ArgumentGenerators::ColumnFamilyInsert do
         }).should eq(expected)
       end
     end
+
+    context "with :upsert key" do
+      it "returns array of arguments with upsert disabled" do
+        cql = "INSERT INTO #{column_family_name} (id, name) VALUES (?, ?) IF NOT EXISTS"
+        expected = [cql, '1', 'GitHub']
+        subject.call({
+          column_family_name: column_family_name,
+          data: {
+            id: '1',
+            name: 'GitHub',
+          },
+          upsert: false
+        }).should eq(expected)
+      end
+    end
   end
 end

--- a/spec/unit/cassanity/argument_generators/column_family_update_spec.rb
+++ b/spec/unit/cassanity/argument_generators/column_family_update_spec.rb
@@ -60,6 +60,33 @@ describe Cassanity::ArgumentGenerators::ColumnFamilyUpdate do
       end
     end
 
+    context "with :if key" do
+      subject {
+        described_class.new({
+          if_clause: lambda { |args|
+            [" IF \"reset_token\" = ?", args.fetch(:if).fetch(:reset_token)]
+          }
+        })
+      }
+
+      it "uses if clause to get additional cql and bound variables" do
+        cql = "UPDATE #{column_family_name} SET reset_token = ? WHERE \"id\" = ? IF \"reset_token\" = ?"
+        expected = [cql, nil, '4', 'randomtoken']
+        subject.call({
+          column_family_name: column_family_name,
+          set: {
+            reset_token: nil,
+          },
+          where: {
+            id: '4',
+          },
+          if: {
+            reset_token: 'randomtoken',
+          }
+        }).should eq(expected)
+      end
+    end
+
     context "with :set key" do
       subject {
         described_class.new({

--- a/spec/unit/cassanity/argument_generators/if_clause_spec.rb
+++ b/spec/unit/cassanity/argument_generators/if_clause_spec.rb
@@ -1,0 +1,52 @@
+require 'helper'
+require 'cassanity/argument_generators/if_clause'
+
+describe Cassanity::ArgumentGenerators::IfClause do
+  describe "#call" do
+    it "returns array of arguments" do
+      subject.call({
+        if: {
+          id: '1',
+        }
+      }).should eq([
+        ' IF "id" = ?',
+        '1',
+      ])
+    end
+
+    context "with nil if" do
+      it "returns array with empty string" do
+        subject.call.should eq([""])
+      end
+    end
+
+    context "with empty if" do
+      it "returns array with empty string" do
+        subject.call(if: {}).should eq([""])
+      end
+    end
+
+    context "with multiple conditions values" do
+      it "returns array of arguments with AND separating if keys" do
+        subject.call({
+          if: {
+            bucket: '2012',
+            id: '1',
+          }
+        }).should eq([
+          ' IF "bucket" = ? AND "id" = ?',
+          '2012',
+          '1',
+        ])
+      end
+    end
+
+    context "with a cassanity equal to operator value" do
+      it "returns correct cql" do
+        subject.call({
+          if: {timestamp: Cassanity::Operators::Eq.new(10)},
+        }).should eq([" IF timestamp = ?", 10])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for lightweight transactions.
http://www.datastax.com/dev/blog/lightweight-transactions-in-cassandra-2-0

There is an additional if clause for updates and an new upsert key for inserts.
Some examples were added in the `examples/column_families.rb` file.