### PR TITLE
Improved migrations version handling

### DIFF
--- a/lib/cassanity/migration_proxy.rb
+++ b/lib/cassanity/migration_proxy.rb
@@ -61,7 +61,7 @@ module Cassanity
     end
 
     def hash
-      path.hash
+      "#{version}_#{name}".hash
     end
 
     def eql?(other)

--- a/spec/unit/cassanity/migration_proxy_spec.rb
+++ b/spec/unit/cassanity/migration_proxy_spec.rb
@@ -57,10 +57,12 @@ describe Cassanity::MigrationProxy do
   end
 
   describe "#hash" do
-    it "delegates to path" do
-      path = '/some/path/1_foo.rb'
+    it "hashes the version and name concatenated" do
+      version = 1
+      name = 'foo'
+      path = "/some/path/00#{version}_#{name}.rb"
       instance = described_class.new(path)
-      instance.hash.should eq(path.hash)
+      instance.hash.should eq("#{version}_#{name}".hash)
     end
   end
 


### PR DESCRIPTION
Following the example in the migrations doc (using 001) as the prefix for my migration, and because I didn't read the disclaimer about the version numbers below :grin: , I've had problems with migrations ordering and once solved I found that padding versions with zeroes makes pending migrations method to fail and tries to rerun the migration. Fixed all of these relying on the version nummeric value rather than alphanummeric one.
