### PR TITLE
Rake tasks and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin
 vendor/gems
 .env
 tags
+.DS_Store

--- a/doc/Migrations.md
+++ b/doc/Migrations.md
@@ -118,4 +118,10 @@ migrator.migrate_to(1, :up)
 
 ## Rake Tasks
 
-What is that? You want some rake tasks to handle migrating? [Here is a gist for that](https://gist.github.com/jnunemaker/5086063). I will try to keep it up to date and I am definitely open to any solutions that would make integrating all of this with your app easier.
+Cassanity defines several useful Rake tasks to manage your migrations. They are:
+
+* `cassanity:migrate`: The most important one. Runs all pending migrations.
+* `cassanity:pending`: Outputs all pending migrations.
+* `cassanity:migrations`: Outputs all migrations.
+* `cassanity:create`: Creates your keyspace (defined in your config/cassanity.erb.yml) if not exists.
+* `cassanity:drop`: Drops your keyspace.

--- a/lib/cassanity.rb
+++ b/lib/cassanity.rb
@@ -154,4 +154,5 @@ module Cassanity
   end
 end
 
+require 'cassanity/config'
 require 'cassanity/client'

--- a/lib/cassanity/config.rb
+++ b/lib/cassanity/config.rb
@@ -1,0 +1,20 @@
+
+require 'ostruct'
+require 'yaml'
+
+module Cassanity
+  class Config < OpenStruct
+    include Singleton
+
+    CONFIG_FILE = 'config/cassanity.yml'
+
+    def initialize
+      super YAML::load_file(CONFIG_FILE)[environment]
+    end
+
+    def environment
+      ENV['CASSANITY_ENV'] || 'development'
+    end
+
+  end
+end

--- a/lib/cassanity/config.rb
+++ b/lib/cassanity/config.rb
@@ -1,6 +1,7 @@
 
 require 'ostruct'
 require 'yaml'
+require 'singleton'
 
 module Cassanity
   class Config < OpenStruct

--- a/lib/cassanity/config.rb
+++ b/lib/cassanity/config.rb
@@ -15,7 +15,7 @@ module Cassanity
     end
 
     def environment
-      ENV['CASSANITY_ENV'] || 'development'
+      ENV['CASSANITY_ENV'] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
     def hosts

--- a/lib/cassanity/config.rb
+++ b/lib/cassanity/config.rb
@@ -2,15 +2,16 @@
 require 'ostruct'
 require 'yaml'
 require 'singleton'
+require 'erb'
 
 module Cassanity
   class Config < OpenStruct
     include Singleton
 
-    CONFIG_FILE = 'config/cassanity.yml'
+    CONFIG_FILE = 'config/cassanity.erb.yml'
 
     def initialize
-      super YAML::load_file(CONFIG_FILE)[environment]
+      super YAML::load(ERB.new(File.read(CONFIG_FILE)).result)[environment]
     end
 
     def environment

--- a/lib/cassanity/config.rb
+++ b/lib/cassanity/config.rb
@@ -5,18 +5,33 @@ require 'singleton'
 require 'erb'
 
 module Cassanity
-  class Config < OpenStruct
+  class Config
     include Singleton
 
     CONFIG_FILE = 'config/cassanity.erb.yml'
 
     def initialize
-      super YAML::load(ERB.new(File.read(CONFIG_FILE)).result)[environment]
+      @table = YAML::load(ERB.new(File.read(CONFIG_FILE)).result)[environment]
     end
 
     def environment
       ENV['CASSANITY_ENV'] || 'development'
     end
 
+    def hosts
+      @table[:hosts]
+    end
+
+    def port
+      @table[:port]
+    end
+
+    def migrations_path
+      @table[:migrations_path]
+    end
+
+    def keyspace
+      @table[:keyspace]
+    end
   end
 end

--- a/lib/cassanity/migration_proxy.rb
+++ b/lib/cassanity/migration_proxy.rb
@@ -50,7 +50,7 @@ module Cassanity
 
     def migration_class
       @migration_class ||= begin
-        require path
+        require File.expand_path(path)
         # TODO: handle constant not found
         Kernel.const_get(constant)
       end

--- a/lib/cassanity/rake_tasks.rb
+++ b/lib/cassanity/rake_tasks.rb
@@ -1,0 +1,11 @@
+require 'rake'
+
+module Cassanity
+  class RakeTasks
+    include Rake::DSL if defined? Rake::DSL
+    def install_tasks
+       load 'tasks/cassanity.rake'
+    end
+  end
+end
+Cassanity::RakeTasks.new.install_tasks

--- a/lib/tasks/cassanity.rake
+++ b/lib/tasks/cassanity.rake
@@ -1,0 +1,69 @@
+namespace :cassanity do
+
+  def display_migrations(migrations)
+    max_size = migrations.map(&:name).map(&:size).max + 1
+    migrations.each do |migration|
+      display_migration migration, size: max_size
+    end
+  end
+
+  def display_migration(migration, options = {})
+    size = options[:size] || migration.name.size
+    puts "- #{migration.name.ljust(size)} #{migration.version}"
+  end
+
+  def migrator
+    @migrator ||= begin
+      require 'cassanity/migrator'
+
+      Cassanity::Migrator.new(keyspace, Cassanity::Config.instance.migrations_path)
+    end
+  end
+
+  def keyspace
+    @keyspace ||= begin
+
+      config = Cassanity::Config.instance
+      Cassanity::Client.new(config.hosts, config.port)[config.keyspace.to_sym]
+    end
+  end
+
+  desc "Run any pending migrations."
+  task :migrate do
+    if ENV["VERSION"]
+      version = ENV["VERSION"].to_i
+      direction = ENV.fetch('DIRECTION', :up).to_sym
+      migrator.migrate_to(version, direction)
+    else
+      migrator.migrate
+    end
+  end
+
+  desc "List pending migrations."
+  task :pending do
+    pending = migrator.pending_migrations
+
+    display_migrations pending
+  end
+
+  desc "List all migrations."
+  task :migrations do
+    display_migrations migrator.migrations
+  end
+
+  desc "Create the keyspace"
+  task :create do
+    unless keyspace.exists?
+      puts "Creating keyspace #{keyspace.name}"
+      keyspace.create
+    end
+  end
+
+  desc "Drop the keyspace"
+  task :drop do
+    if keyspace.exists?
+      puts "Dropping keyspace #{keyspace.name}"
+      keyspace.drop
+    end
+  end
+end

--- a/lib/tasks/cassanity.rake
+++ b/lib/tasks/cassanity.rake
@@ -1,15 +1,14 @@
 namespace :cassanity do
 
   def display_migrations(migrations)
-    max_size = (migrations.map(&:name).map(&:size).max || 0) + 1
+    left_padding = (migrations.map(&:name).map(&:size).max || 0) + 1
     migrations.each do |migration|
-      display_migration migration, size: max_size
+      display_migration migration, left_padding
     end
   end
 
-  def display_migration(migration, options = {})
-    size = options[:size] || migration.name.size
-    puts "- #{migration.name.ljust(size)} #{migration.version}"
+  def display_migration(migration, left_padding)
+    puts "- #{migration.name.ljust(left_padding)} #{migration.version}"
   end
 
   def build_migrator

--- a/lib/tasks/cassanity.rake
+++ b/lib/tasks/cassanity.rake
@@ -1,67 +1,83 @@
 namespace :cassanity do
 
-  def display_migrations(migrations)
-    left_padding = (migrations.map(&:name).map(&:size).max || 0) + 1
-    migrations.each do |migration|
-      display_migration migration, left_padding
+  class CassanityRakeHelper
+    # This class is merely a container of data and methods for this rake tasks.
+    # It is basically to avoid cluttering the top level ruby object with this
+    # convenience methods/attributes. This is because Rake runs in the top level
+    # object as it's context.
+    include Singleton
+
+    def self.migrator
+      instance.migrator
+    end
+
+    def self.keyspace
+      instance.keyspace
+    end
+
+    def self.display_migrations(migrations)
+      left_padding = (migrations.map(&:name).map(&:size).max || 0) + 1
+      migrations.each do |migration|
+        display_migration migration, left_padding
+      end
+    end
+
+    def self.display_migration(migration, left_padding)
+      puts "- #{migration.name.ljust(left_padding)} #{migration.version}"
+    end
+
+    def migrator
+      @migrator ||= begin
+        require 'cassanity/migrator'
+
+        Cassanity::Migrator.new(keyspace, Cassanity::Config.instance.migrations_path)
+      end
+    end
+
+    def keyspace
+      @keyspace ||= begin
+        config = Cassanity::Config.instance
+        Cassanity::Client.new(config.hosts, config.port)[config.keyspace.to_sym]
+      end
     end
   end
 
-  def display_migration(migration, left_padding)
-    puts "- #{migration.name.ljust(left_padding)} #{migration.version}"
-  end
-
-  def build_migrator
-    require 'cassanity/migrator'
-
-    Cassanity::Migrator.new(get_keyspace, Cassanity::Config.instance.migrations_path)
-  end
-
-  def get_keyspace
-    config = Cassanity::Config.instance
-    Cassanity::Client.new(config.hosts, config.port)[config.keyspace.to_sym]
-  end
-
   desc "Run any pending migrations."
-  task :migrate do
-    migrator = build_migrator
+  task :migrate => [:create] do
     if ENV["VERSION"]
       version = ENV["VERSION"].to_i
       direction = ENV.fetch('DIRECTION', :up).to_sym
-      migrator.migrate_to(version, direction)
+      CassanityRakeHelper.migrator.migrate_to(version, direction)
     else
-      migrator.migrate
+      CassanityRakeHelper.migrator.migrate
     end
   end
 
   desc "List pending migrations."
   task :pending do
-    migrator = build_migrator
-    pending = migrator.pending_migrations
-    display_migrations pending
+    pending = CassanityRakeHelper.migrator.pending_migrations
+    CassanityRakeHelper.display_migrations pending
   end
 
   desc "List all migrations."
   task :migrations do
-    migrator = build_migrator
-    display_migrations migrator.migrations
+    migrations = CassanityRakeHelper.migrator.migrations
+    CassanityRakeHelper.display_migrations migrations
   end
 
   desc "Create the keyspace"
   task :create do
-    ks = get_keyspace
-    unless ks.exists?
-      puts "Creating keyspace #{ks.name}"
-      ks.create
+    unless CassanityRakeHelper.keyspace.exists?
+      puts "Creating keyspace #{CassanityRakeHelper.keyspace.name}"
+      CassanityRakeHelper.keyspace.create
     end
   end
 
   desc "Drop the keyspace"
   task :drop do
-    ks = get_keyspace
-    if ks.exists?
-      puts "Dropping keyspace #{ks.name}"
-      ks.drop
+    if CassanityRakeHelper.keyspace.exists?
+      puts "Dropping keyspace #{CassanityRakeHelper.keyspace.name}"
+      CassanityRakeHelper.keyspace.drop
     end
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -30,3 +30,4 @@ end
 
 CassanityHost = Array(ENV.fetch('CASSANITY_HOST', '127.0.0.1'))
 CassanityPort = ENV.fetch('CASSANITY_PORT', '9042').to_i
+ENV['CASSANITY_ENV'] = 'test'

--- a/spec/migrations/1_create_a.rb
+++ b/spec/migrations/1_create_a.rb
@@ -1,0 +1,12 @@
+class CreateA < Cassanity::Migration
+  def up
+    create_column_family :a, {
+      primary_key: :id,
+      columns: { id: :int }
+    }
+  end
+
+  def down
+    drop_column_family :a
+  end
+end

--- a/spec/migrations/2_create_b.rb
+++ b/spec/migrations/2_create_b.rb
@@ -1,0 +1,12 @@
+class CreateB < Cassanity::Migration
+  def up
+    create_column_family :b, {
+      primary_key: :id,
+      columns: { id: :int }
+    }
+  end
+
+  def down
+    drop_column_family :b
+  end
+end

--- a/spec/support/cassanity.erb.yml
+++ b/spec/support/cassanity.erb.yml
@@ -1,6 +1,6 @@
 default: &default
   :hosts: [127.0.0.1]
-  :port: 9042
+  :port: <%= ENV['CASSANDRA_PORT'] || 9042 %>
   :migrations_path: 'lib/db/migrations'
 
 development:

--- a/spec/support/cassanity.erb.yml
+++ b/spec/support/cassanity.erb.yml
@@ -10,6 +10,7 @@ development:
 test:
   <<: *default
   :keyspace: cassanity_test
+  :migrations_path: 'spec/migrations'
 
 production:
   <<: *default

--- a/spec/support/cassanity.yml
+++ b/spec/support/cassanity.yml
@@ -1,0 +1,16 @@
+default: &default
+  :hosts: [127.0.0.1]
+  :port: 9042
+  :migrations_path: 'lib/db/migrations'
+
+development:
+  <<: *default
+  :keyspace: cassanity_dev
+
+test:
+  <<: *default
+  :keyspace: cassanity_test
+
+production:
+  <<: *default
+  :keyspace: cassanity

--- a/spec/support/migrations_shared_context.rb
+++ b/spec/support/migrations_shared_context.rb
@@ -1,8 +1,5 @@
 shared_context 'migrations' do
-  let(:migrator) { double Cassanity::Migrator }
-
   before do
     stub_const 'Cassanity::Config::CONFIG_FILE', 'spec/support/cassanity.erb.yml'
-    allow(Cassanity::Migrator).to receive(:new).and_return migrator
   end
 end

--- a/spec/support/migrations_shared_context.rb
+++ b/spec/support/migrations_shared_context.rb
@@ -1,0 +1,8 @@
+shared_context 'migrations' do
+  let(:migrator) { double Cassanity::Migrator }
+
+  before do
+    stub_const 'Cassanity::Config::CONFIG_FILE', 'spec/support/cassanity.erb.yml'
+    allow(Cassanity::Migrator).to receive(:new).and_return migrator
+  end
+end

--- a/spec/support/rake_shared_context.rb
+++ b/spec/support/rake_shared_context.rb
@@ -1,0 +1,22 @@
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  let(:all_tasks_path) { Pathname.new File.expand_path('../../../lib/tasks', __FILE__) }
+
+  def loaded_files_excluding_current_rake_file
+    # Remove the tested file from the loaded paths
+    $".reject {|file| file == all_tasks_path.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [all_tasks_path.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/support/rake_shared_context.rb
+++ b/spec/support/rake_shared_context.rb
@@ -5,6 +5,7 @@ shared_context "rake" do
   let(:task_name) { self.class.top_level_description }
   let(:task_path) { "#{task_name.split(":").first}" }
   subject         { rake[task_name] }
+  let(:main)      { TOPLEVEL_BINDING.eval('self') }
 
   let(:all_tasks_path) { Pathname.new File.expand_path('../../../lib/tasks', __FILE__) }
 

--- a/spec/support/rake_shared_context.rb
+++ b/spec/support/rake_shared_context.rb
@@ -5,7 +5,6 @@ shared_context "rake" do
   let(:task_name) { self.class.top_level_description }
   let(:task_path) { "#{task_name.split(":").first}" }
   subject         { rake[task_name] }
-  let(:main)      { TOPLEVEL_BINDING.eval('self') }
 
   let(:all_tasks_path) { Pathname.new File.expand_path('../../../lib/tasks', __FILE__) }
 

--- a/spec/unit/cassanity/config_spec.rb
+++ b/spec/unit/cassanity/config_spec.rb
@@ -14,6 +14,7 @@ describe Cassanity::Config do
   end
 
   it 'successfully reads port config' do
+    ENV.delete 'CASSANDRA_PORT'
     config.port.should eq 9042
   end
 

--- a/spec/unit/cassanity/config_spec.rb
+++ b/spec/unit/cassanity/config_spec.rb
@@ -1,0 +1,31 @@
+require 'helper'
+require 'cassanity/config'
+
+describe Cassanity::Config do
+
+  before do
+    stub_const 'Cassanity::Config::CONFIG_FILE', 'spec/support/cassanity.yml'
+  end
+
+  let(:config) { Class.new(Cassanity::Config).instance }
+
+  it 'successfully reads hosts config' do
+    config.hosts.should eq ['127.0.0.1']
+  end
+
+  it 'successfully reads port config' do
+    config.port.should eq 9042
+  end
+
+  { development: '_dev', test: '_test', production: '' }.each do |env, suffix|
+    it "successfully reads #{env} keyspace config" do
+      ENV['CASSANITY_ENV'] = env.to_s
+      config.keyspace.should eq "cassanity#{suffix}"
+    end
+  end
+
+  it 'successfully reads migrations path' do
+    config.migrations_path.should eq 'lib/db/migrations'
+  end
+
+end

--- a/spec/unit/cassanity/config_spec.rb
+++ b/spec/unit/cassanity/config_spec.rb
@@ -4,7 +4,7 @@ require 'cassanity/config'
 describe Cassanity::Config do
 
   before do
-    stub_const 'Cassanity::Config::CONFIG_FILE', 'spec/support/cassanity.yml'
+    stub_const 'Cassanity::Config::CONFIG_FILE', 'spec/support/cassanity.erb.yml'
   end
 
   let(:config) { Class.new(Cassanity::Config).instance }
@@ -15,6 +15,11 @@ describe Cassanity::Config do
 
   it 'successfully reads port config' do
     config.port.should eq 9042
+  end
+
+  it 'successfully parses erb port config' do
+    ENV['CASSANDRA_PORT'] = '1111'
+    config.port.should eq 1111
   end
 
   { development: '_dev', test: '_test', production: '' }.each do |env, suffix|

--- a/spec/unit/cassanity/config_spec.rb
+++ b/spec/unit/cassanity/config_spec.rb
@@ -7,6 +7,10 @@ describe Cassanity::Config do
     stub_const 'Cassanity::Config::CONFIG_FILE', 'spec/support/cassanity.erb.yml'
   end
 
+  after do
+    ENV['CASSANITY_ENV'] = 'test'
+  end
+
   let(:config) { Class.new(Cassanity::Config).instance }
 
   it 'successfully reads hosts config' do
@@ -31,7 +35,7 @@ describe Cassanity::Config do
   end
 
   it 'successfully reads migrations path' do
-    config.migrations_path.should eq 'lib/db/migrations'
+    config.migrations_path.should eq 'spec/migrations'
   end
 
 end

--- a/spec/unit/tasks/cassanity_rake_spec.rb
+++ b/spec/unit/tasks/cassanity_rake_spec.rb
@@ -36,8 +36,6 @@ describe 'cassanity:pending' do
   include_context 'rake'
   include_context 'migrations'
 
-  let(:main) { TOPLEVEL_BINDING.eval('self') }
-
   it 'lists pending migrations' do
     migration_name = 'Migration1'
     migration = double Cassanity::MigrationProxy, name: migration_name
@@ -51,6 +49,28 @@ describe 'cassanity:pending' do
 
   it 'lists nothing if no pending migrations' do
     allow(migrator).to receive(:pending_migrations).and_return []
+    expect(main).not_to receive :display_migration
+    subject.invoke
+  end
+end
+
+describe 'cassanity:migrations' do
+  include_context 'rake'
+  include_context 'migrations'
+
+  it 'lists all migrations' do
+    migration_name = 'Migration1'
+    migration = double Cassanity::MigrationProxy, name: migration_name
+    migration_name2 = 'Migration_2'
+    migration2 = double Cassanity::MigrationProxy, name: migration_name2
+    allow(migrator).to receive(:migrations).and_return [migration, migration2]
+    expect(main).to receive(:display_migration).with(migration, migration_name2.size + 1)
+    expect(main).to receive(:display_migration).with(migration2, migration_name2.size + 1)
+    subject.invoke
+  end
+
+  it 'lists nothing if no pending migrations' do
+    allow(migrator).to receive(:migrations).and_return []
     expect(main).not_to receive :display_migration
     subject.invoke
   end

--- a/spec/unit/tasks/cassanity_rake_spec.rb
+++ b/spec/unit/tasks/cassanity_rake_spec.rb
@@ -75,3 +75,23 @@ describe 'cassanity:migrations' do
     subject.invoke
   end
 end
+
+describe 'cassanity:create' do
+  include_context 'rake'
+  include_context 'migrations'
+
+  let(:keyspace) { main.send :get_keyspace }
+
+  it 'creates if not exists' do
+    keyspace.drop if keyspace.exists?
+    expect {
+      subject.invoke
+    }.to change(keyspace, :exists?).from(false).to true
+  end
+
+  it "doesn't create if already exists" do
+    keyspace.create unless keyspace.exists?
+    expect(keyspace).not_to receive :create
+    subject.invoke
+  end
+end

--- a/spec/unit/tasks/cassanity_rake_spec.rb
+++ b/spec/unit/tasks/cassanity_rake_spec.rb
@@ -3,13 +3,7 @@ require 'cassanity/migrator'
 
 describe 'cassanity:migrate' do
   include_context 'rake'
-
-  let(:migrator) { double Cassanity::Migrator }
-
-  before do
-    stub_const 'Cassanity::Config::CONFIG_FILE', 'spec/support/cassanity.erb.yml'
-    allow(Cassanity::Migrator).to receive(:new).and_return migrator
-  end
+  include_context 'migrations'
 
   it 'migrates' do
     expect(migrator).to receive :migrate
@@ -35,5 +29,29 @@ describe 'cassanity:migrate' do
       expect(migrator).to receive(:migrate_to).with target_version, :down
       subject.invoke
     end
+  end
+end
+
+describe 'cassanity:pending' do
+  include_context 'rake'
+  include_context 'migrations'
+
+  let(:main) { TOPLEVEL_BINDING.eval('self') }
+
+  it 'lists pending migrations' do
+    migration_name = 'Migration1'
+    migration = double Cassanity::MigrationProxy, name: migration_name
+    migration_name2 = 'Migration_2'
+    migration2 = double Cassanity::MigrationProxy, name: migration_name2
+    allow(migrator).to receive(:pending_migrations).and_return [migration, migration2]
+    expect(main).to receive(:display_migration).with(migration, migration_name2.size + 1)
+    expect(main).to receive(:display_migration).with(migration2, migration_name2.size + 1)
+    subject.invoke
+  end
+
+  it 'lists nothing if no pending migrations' do
+    allow(migrator).to receive(:pending_migrations).and_return []
+    expect(main).not_to receive :display_migration
+    subject.invoke
   end
 end

--- a/spec/unit/tasks/cassanity_rake_spec.rb
+++ b/spec/unit/tasks/cassanity_rake_spec.rb
@@ -95,3 +95,23 @@ describe 'cassanity:create' do
     subject.invoke
   end
 end
+
+describe 'cassanity:drop' do
+  include_context 'rake'
+  include_context 'migrations'
+
+  let(:keyspace) { main.send :get_keyspace }
+
+  it 'drops if exists' do
+    keyspace.create unless keyspace.exists?
+    expect {
+      subject.invoke
+    }.to change(keyspace, :exists?).from(true).to false
+  end
+
+  it "doesn't drop if already doesn't exist" do
+    keyspace.drop if keyspace.exists?
+    expect(keyspace).not_to receive :drop
+    subject.invoke
+  end
+end

--- a/spec/unit/tasks/cassanity_rake_spec.rb
+++ b/spec/unit/tasks/cassanity_rake_spec.rb
@@ -1,0 +1,39 @@
+require 'helper'
+require 'cassanity/migrator'
+
+describe 'cassanity:migrate' do
+  include_context 'rake'
+
+  let(:migrator) { double Cassanity::Migrator }
+
+  before do
+    stub_const 'Cassanity::Config::CONFIG_FILE', 'spec/support/cassanity.erb.yml'
+    allow(Cassanity::Migrator).to receive(:new).and_return migrator
+  end
+
+  it 'migrates' do
+    expect(migrator).to receive :migrate
+    subject.invoke
+  end
+
+  context 'specifying target version' do
+
+    let(:target_version) { 139 }
+
+    before do
+      ENV.delete 'DIRECTION'
+      ENV['VERSION'] = target_version.to_s
+    end
+
+    it 'migrates up to a specific version' do
+      expect(migrator).to receive(:migrate_to).with target_version, :up
+      subject.invoke
+    end
+
+    it 'migrates down to a specific version' do
+      ENV['DIRECTION'] = 'down'
+      expect(migrator).to receive(:migrate_to).with target_version, :down
+      subject.invoke
+    end
+  end
+end


### PR DESCRIPTION
This branch is not ready to be merged yet, but just opened the PR to have feedback from @jnunemaker 

The idea was to add the rake tasks to the gem so that they can be easily used just by adding
`require 'cassanity/rake_tasks'` to the project's Rakefile.

All docs are still to be updated, but didn't want to do it until you reviewed the functionality.

Also I'd like to let the Cassandra::Client get the defaults by Config rather than having them hardcoded.