### PR TITLE
Add inclusive range placeholders

### DIFF
--- a/lib/cassanity/argument_generators/prepared_where_clause.rb
+++ b/lib/cassanity/argument_generators/prepared_where_clause.rb
@@ -12,7 +12,7 @@ module Cassanity
 
     attr_reader :comparator
 
-    def initialize(exclusive: true)
+    def initialize(exclusive = true)
       @comparator = exclusive ? '<' : '<='
     end
   end

--- a/lib/cassanity/argument_generators/prepared_where_clause.rb
+++ b/lib/cassanity/argument_generators/prepared_where_clause.rb
@@ -8,7 +8,14 @@ require 'cassanity/range'
 
 module Cassanity
 
-  class RangePlaceholder ; end
+  class RangePlaceholder
+
+    attr_reader :comparator
+
+    def initialize(exclusive: true)
+      @comparator = exclusive ? '<' : '<='
+    end
+  end
 
   class SingleFieldPlaceholder
 
@@ -46,7 +53,7 @@ module Cassanity
             wheres << "#{key} IN (#{binds})"
           when RangePlaceholder
             wheres << "#{key} >= ?"
-            wheres << "#{key} < ?"
+            wheres << "#{key} #{value.comparator} ?"
           when SingleFieldPlaceholder
             wheres << "\"#{key}\" #{value.symbol} ?"
           end

--- a/lib/cassanity/version.rb
+++ b/lib/cassanity/version.rb
@@ -1,3 +1,3 @@
 module Cassanity
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end

--- a/lib/cassanity/version.rb
+++ b/lib/cassanity/version.rb
@@ -1,3 +1,3 @@
 module Cassanity
-  VERSION = "0.9.0"
+  VERSION = "0.8.0"
 end

--- a/spec/integration/cassanity/column_family_spec.rb
+++ b/spec/integration/cassanity/column_family_spec.rb
@@ -441,7 +441,7 @@ describe Cassanity::ColumnFamily do
               select: :event,
               where: {
                 app_id: Cassanity::SingleFieldPlaceholder.new,
-                time: Cassanity::RangePlaceholder.new(exclusive: false)
+                time: Cassanity::RangePlaceholder.new(false)
               }
             })
 

--- a/spec/integration/cassanity/column_family_spec.rb
+++ b/spec/integration/cassanity/column_family_spec.rb
@@ -424,7 +424,7 @@ describe Cassanity::ColumnFamily do
         end
 
         describe 'ranges' do
-          it 'works with ranges' do
+          it 'works with (and defaults to) exclusive ranges' do
             stmt = column_family.prepare_select({
               select: :event,
               where: {
@@ -436,7 +436,19 @@ describe Cassanity::ColumnFamily do
             expect(stmt.execute app_id: '1', time: (start_time..(start_time+2))).to eq [{'event' => 'event0'}, {'event' => 'event1'}]
           end
 
-          it 'allows edges inclusion/exclusion configuration'
+          it 'works with inclusive ranges' do
+            stmt = column_family.prepare_select({
+              select: :event,
+              where: {
+                app_id: Cassanity::SingleFieldPlaceholder.new,
+                time: Cassanity::RangePlaceholder.new(exclusive: false)
+              }
+            })
+
+            expect(stmt.execute app_id: '1', time: (start_time..(start_time+2))).to eq [
+              {'event' => 'event0'}, {'event' => 'event1'}, {'event' => 'event2'}
+            ]
+          end
         end
 
         it 'works with non equals operators' do


### PR DESCRIPTION
The RangePlaceholder only caters for ranges which are exclusive of the end value.

This pull request adds support for inclusive ranges while maintaining the current behaviour so as not to break any existing installations.
